### PR TITLE
Updated Links To FIA pages (DATIM #6778)

### DIFF
--- a/ProjectsPage.html
+++ b/ProjectsPage.html
@@ -273,7 +273,7 @@
             <h6 class="h6 text-uppercase mb-4 font-weight-bold">Useful links</h6>
 
             <ul style="list-style-type:none;">
-              <li><a href="https://www.fia.fs.usda.gov/" target="_blank">FIA Website</a></li>
+              <li><a href="https://www.fs.usda.gov/research/programs/fia" target="_blank">FIA Website</a></li>
               <li><a href="https://www.unlv.edu/" target="_blank">UNLV Website</a></li>
               <li><a href="https://geoscience.unlv.edu/" target="_blank">UNLV - Geoscience Department Website</a></li>
             </ul>

--- a/TeamPage.html
+++ b/TeamPage.html
@@ -1228,7 +1228,7 @@
             <h6 class="h6 text-uppercase mb-4 font-weight-bold">Useful links</h6>
 
             <ul style="list-style-type:none;">
-              <li><a href="https://www.fia.fs.usda.gov/" target="_blank">FIA Website</a></li>
+              <li><a href="https://www.fs.usda.gov/research/programs/fia" target="_blank">FIA Website</a></li>
               <li><a href="https://www.unlv.edu/" target="_blank">UNLV Website</a></li>
               <li><a href="https://geoscience.unlv.edu/" target="_blank">UNLV - Geoscience Department Website</a></li>
             </ul>

--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
           <h6 class="h6 text-uppercase mb-4 font-weight-bold">Useful links</h6>
     
           <ul style="list-style-type:none;">
-            <li><a href="https://www.fia.fs.usda.gov/" target="_blank">FIA Website</a></li>
+            <li><a href="https://www.fs.usda.gov/research/programs/fia" target="_blank">FIA Website</a></li>
             <li><a href="https://www.unlv.edu/" target="_blank">UNLV Website</a></li>
             <li><a href="https://geoscience.unlv.edu/" target="_blank">UNLV - Geoscience Department Website</a></li>
           </ul>


### PR DESCRIPTION
This ticket completes the UNLV-FIA portion of DATIM ticket #6778 (https://code.fs.usda.gov/forest-service/DATIM/issues/6778). 

The FIA Homepage now uses the correct link.