### PR TITLE
#252 (Team Page) Add Apollo Draco's profile | Based on main

### DIFF
--- a/TeamPage.html
+++ b/TeamPage.html
@@ -516,7 +516,7 @@
                         He earned a Bachelor of Science Degree in Computer Science from UNLV in the Spring 2024.
                         Zach will be working as an engineer on DATIM and other projects. In his spare time, Zach enjoys 
                         riding motorcycles, playing video games, and working on personal projects.
-                      <p>
+                      </p>
                         <table aria-label="Skills" class="table table-striped table-dark">
                           <tbody>
                             <tr>
@@ -530,6 +530,47 @@
                           </tbody>
                         </table>
                       </div>
+                    <div class="modal-footer">
+                      <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-3 col-xs" style="min-width: 210px;">
+          <div class="id_presentation">
+            <img class="img_staff"
+              src="https://i.imgur.com/nAxNCpf.jpeg"
+              style="object-position: top;" alt="Apollo's Picture" />
+            <div class="text_pres">Apollo Draco<br>
+              <div class="subtext_pres">Student Accessibility Tester</div>
+            </div>
+            <div class="container" style="text-align: center;">
+              <button type="button" style="margin-top: 10px;" class="btn btn-danger btn-sm" data-toggle="modal"
+                data-target="#myModalApollo" onclick="openBSModal('myModalApollo', this)">Apollo's Profile</button>
+              <div class="modal fade" tabindex="-1" id="myModalApollo" role="dialog" datim-modal>
+                <div class="modal-dialog">
+                  <div class="modal-content">
+                    <div class="modal-header">
+                      <div class="modal-title">
+                        <p class="text-justify"><b>Apollo Draco</b> - Student Accessibility Tester<br>
+                          Work Location: Remote<br>
+                          Email: apollo.draco@unlv.edu</p>
+                      </div>
+                      <button type="button" class="close" data-dismiss="modal" aria-label="close">x</button>
+                    </div>
+                    <div class="modal-body">
+                      <p class="text-justify">Apollo joined the UNLV-FIA group as a student Web Accessibility
+                        Tester in June 2024. Apollo is working on earning his certification to become a 
+                        Trusted Tester through the Department of Homeland Security and will be assessing web
+                        content with a goal to improve accessibility utilizing Section 508 and Web Content 
+                        Accessibility Guidelines (WCAG) on DATIM. He is an Information Systems major, and 
+                        has experience in System Administration. In his spare time, Apollo enjoys D&D, 
+                        hiking, and reading fantasy novels.
+                      </p>
+                    </div>
                     <div class="modal-footer">
                       <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
                     </div>


### PR DESCRIPTION
Addresses #252, adds Apollo Draco's profile to the UNLV-FIA team page.

## CODE CHANGES
1. Added Apollo's profile.