### PR TITLE
#277 Remove James Menlove's profile | Based on Main

### DIFF
--- a/TeamPage.html
+++ b/TeamPage.html
@@ -798,46 +798,6 @@
         </div>
         <div class="col-sm-3 col-xs" style="min-width: 210px;">
           <div class="id_presentation">
-            <img class="img_staff" src="https://zupimages.net/up/21/04/h4e8.jpg" alt="James's Picture" />
-            <div class="text_pres">James Menlove<br>
-              <div class="subtext_pres">Ecologist</div>
-            </div>
-            <div class="container" style="text-align: center;">
-              <button type="button" style="margin-top: 10px;" class="btn btn-danger btn-sm" data-toggle="modal"
-                data-target="#myModal22" onclick="openBSModal('myModal22', this)">James' Profile</button>
-              <div class="modal fade" tabindex="-1" id="myModal22" role="dialog" datim-modal>
-                <div class="modal-dialog">
-                  <div class="modal-content">
-                    <div class="modal-header">
-                      <div class="modal-title">
-                        <p class="text-justify"><b>James Menlove</b> - Ecologist<br>
-                          Work Location: Remote<br>
-                          Email: james.menlove@unlv.edu<br>
-                      </div>
-                      <button type="button" class="close" data-dismiss="modal" aria-label="close">x</button>
-                    </div>
-                    <div class="modal-body">
-                      <p class="text-justify">James Menlove began working for the USDA Forest Service in 1997 and retired in 
-                        December 2020. During his time with the Forest Service, James worked on Shoshone and Bighorn National 
-                        Forests in Wyoming, collected FIA field data for Ogden UT lab, was an FIA analyst at RMRS FIA, and was 
-                        a member of the DATIM core team representing RMRS FIA. Following his retirement from the Forest Service, 
-                        James joined the UNLV-FIA group as an Ecologist/subject-matter expert and is an important contributor 
-                        to the DATIM and EVALIDator projects. James received his M.S. in Zoology & Physiology (emphasis Ecology) 
-                        from the University of Wyoming. In his spare time, James enjoys spending time with his family and playing 
-                        music.
-                      </p>
-                    </div>
-                    <div class="modal-footer">
-                      <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="col-sm-3 col-xs" style="min-width: 210px;">
-          <div class="id_presentation">
             <img class="img_staff" src="https://zupimages.net/up/20/48/5f6d.jpg" alt="Kelvyn's Picture" />
             <div class="text_pres">Kelvyn Meyers<br>
               <div class="subtext_pres">Senior Software Engineer</div>


### PR DESCRIPTION
Addresses #277. Removed James Menlove's profile due to retirement.

## CODE CHANGES
1. Deleted the code that corresponded to James Menlove's profile.