### PR TITLE
#280 (Home) Add USDA Disclaimer | Based on Main

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,13 @@
     <p style="color:black">Our staff at UNLV works in partnership with the Forest Inventory and Analysis (FIA) National Operations Team to optimize and standardize the use of analytical tools and data structure maintenance. We collaborate with FIA staff on a variety of data management and data delivery system projects and co-tasks.
       <div style="text-align: center;"><a href="ProjectsPage.html" class="btn btn-danger btn-sm" role="button" tabindex="0">Co-Projects List</a></div>
 </section>
+<section id="nonDiscriminationStatement" class="section section-light" style="padding: 0% 22% 3%">
+    <h2>Nondiscrimination Statement</h2><br>
+    <p style="color:black">
+        <b><i>In accordance with Federal law and U.S. Department of Agriculture policy, this institution is prohibited from discriminating on the basis of race, color, national origin, sex, age, or disability. (Not all prohibited bases apply to all programs.)</i></b>
+        <br /><br />
+        To file a complaint alleging discrimination, write USDA, Director, Office of Civil Rights, 1400 Independence Avenue, SW, Washington DC 20250-9410 or call toll free voice (866) 632-9992, TDD (800)877-8339, or voice relay (866) 377-8642. USDA is an equal opportunity provider and employer.
+</section>
     <!-- Footer -->
     <div style="font-size: 17px;">
 <footer class="page-footer font-small bg-dark pt-4 text-secondary">


### PR DESCRIPTION
Addressed #280. Added a USDA nondiscrimination statement due to the cooperative agreement between UNLV and the forest service. The section is above the footer and below the "Our Co-Projects" section based off looking at other statements that other websites have (they've dedicated a whole webpage for this)

## CODE CHANGES
1. Added a section to include the USDA disclaimer according to the requirements of #280.